### PR TITLE
Mark PR #3 as a breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.7.0 (2021-08-31)
 
-#### :rocket: Enhancement
+#### :boom: Breaking Change
 * [#3](https://github.com/lblod/ember-vo-mu-file-upload/pull/3) made model name configurable changed default endpoint ([@Asergey91](https://github.com/Asergey91))
 
 #### Committers: 1


### PR DESCRIPTION
The default endpoint change is a breaking change for apps that depended on the previous default value. So I'm marking it like that in the changelog to make it easier to notice.